### PR TITLE
test: Fix intermittent teardown failures in bats test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -66,12 +66,11 @@ health_checks() {
 }
 
 teardown() {
-  set -eu -o pipefail
 #  echo "# LEAVING ${TESTDIR} for you" >&3
-  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
-
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
+  [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}" || true
 }
+
 
 # bats test_tags=from-directory
 @test "install from directory" {


### PR DESCRIPTION
## The Issue

Automated tests were failing intermittently during teardown with `rm -rf` errors, even though the command should force removal. The failures were unpredictable and occurred in GitHub Actions CI.

Example: https://github.com/ddev/ddev-php85/actions/runs/18613287473/job/53074416697#step:2:195

## How This Solves The Issue

- Removed `set -eu -o pipefail` from teardown() to prevent errors from causing teardown to fail
- Added `|| true` to both `ddev delete` and `rm -rf` commands to make cleanup best-effort
- Teardown failures are now non-fatal since cleanup is cosmetic on ephemeral CI infrastructure (the VM gets destroyed anyway)
- Uniquely named test directories prevent interference between tests anyway even if cleanup fails

## Automated Testing Overview

The existing test suite validates this change. Tests shouldn't fail due to teardown cleanup issues.

