### PR TITLE
Archive PHP 8.5 add-on in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-php85)](https://github.com/ddev/ddev-php85/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-php85)](https://github.com/ddev/ddev-php85/releases/latest)
 
+# DDEV v1.24.10 now has PHP 8.5, so this add-on is archived. Until next year!
+
 # DDEV PHP 8.5 Add-on <!-- omit in toc -->
 
 This add-on provides experimental PHP 8.5 support for DDEV projects using pre-release PHP 8.5 images.


### PR DESCRIPTION
Updated README to indicate archiving of the PHP 8.5 add-on.

## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-php85/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
